### PR TITLE
by Eugene aGGreSSor Sobolev

### DIFF
--- a/russian.ct
+++ b/russian.ct
@@ -1,0 +1,88 @@
+## version $VER: SysMon.catalog 1.2 (13.12.2020)
+## language russian
+## codeset 2104
+;
+; Don’t pay attention to MSG_nonsene. In original sysmon.cd all enumerators are confused.
+; For the correct translation to be in place, consistency is important.
+;
+MSG_APP_NAME
+SysMon
+;
+MSG_APP_TITLE
+Системный монитор
+;
+MSG_WINDOW_TITLE
+Системный монитор
+;
+MSG_USAGE
+Обновить
+;
+MSG_FREQUENCY
+Автообновление (1 сек.)
+;
+MSG_TAB_TASKS
+Использование
+;
+MSG_TAB_CPU
+Процессор(ы)
+;
+MSG_SIMULATED_CPU
+Задачи
+;
+MSG_PROCESS
+Процессор #%id: %s
+;
+MSG_TASK
+Переведи_1
+;
+MSG_PROCESSOR
+Процессоры
+;
+MSG_TASK_NAME
+Задача
+;
+MSG_TASK_PRIORITY
+Процесс
+;
+MSG_TASK_TYPE
+Название
+;
+MSG_TASK_READY_WAIT_INIT
+Приоритет
+;
+MSG_TASK_READY_WAIT
+Тип
+;
+MSG_TAB_SYSTEM
+%ld готовы, %ld ожидают
+;
+MSG_MEMORY_SIZE
+Система
+;
+MSG_MEMORY_FREE
+Системная память
+;
+MSG_VIDEO_SIZE
+Свободно памяти
+;
+MSG_VIDEO_FREE
+Видеопамять
+;
+MSG_TOTAL_RAM
+Свободно видеопамяти
+;
+MSG_CHIP_RAM
+Всего
+;
+MSG_FAST_RAM
+Chip
+;
+MSG_VIDEO_RAM
+Fast
+;
+MSG_VIDEO_WINDOW_TMPL
+Всего
+;
+MSG_CANT_OPEN_TASK_RESOURCE
+Таблица GART
+;


### PR DESCRIPTION
sysmon.cd has the wrong message sequence, so any <language>.ct mess up the interface...
I wrote russian.ct based on the correct sequence, so the resulting file sysmon.catalog works fine.
I didn't fix the catalog descriptor file and other people's translations, because everything needs to be redone there.
![sysmon](https://user-images.githubusercontent.com/3582394/102017620-08a06a80-3d79-11eb-8785-e23ff6a4bf1b.png)
![sysmon_2](https://user-images.githubusercontent.com/3582394/102017622-0a6a2e00-3d79-11eb-8f63-a1ed5c86a8a4.png)
![sysmon_3](https://user-images.githubusercontent.com/3582394/102017623-0c33f180-3d79-11eb-9e8d-4b307b12018e.png)

